### PR TITLE
Po c a16 fix

### DIFF
--- a/kilnControl/kiln.py
+++ b/kilnControl/kiln.py
@@ -367,19 +367,21 @@ class Kiln:
                 moHardware.EmergencyOff()
                 return
             
-        if (self.kilnTemps[0] <= 1.0):
-            # should never get below 1C (0 is indicator of error)
-            log.error("Kiln ERROR: average temp is below zero! "+str(self.kilnTemps[0]))
-            log.error("there is error somewhere, so shutdown")
-            moHardware.EmergencyOff()
-            return
-    
         if self.state == KilnState.Idle:
             #print("Kiln idle step")
             # after collecting, nothing left to do in Idle
             return
         
         #log.info("kilnStep not Idle = " + str(self.state))
+
+        if self.kilnTemps[0] <= 1.0 and simulation == False:
+            # should never get below 1C (0 is indicator of error)
+            # dont kill it yet, just dot let it run non-simulated script
+            log.warning("Kiln Warning: average temp is below 1C! " + str(self.kilnTemps[0]))
+            # log.error("there is error somewhere, so shutdown")
+            # moHardware.EmergencyOff()
+            self.terminateScript()
+            return
 
         if (self.processRuntime >= self.maxTimeSec):
             log.error("Max Time for script exceeded, abort script")

--- a/kilnControl/kiln.py
+++ b/kilnControl/kiln.py
@@ -367,8 +367,8 @@ class Kiln:
                 moHardware.EmergencyOff()
                 return
             
-        if (self.kilnTemps[0] < 0.0):
-            # should never get below zero
+        if (self.kilnTemps[0] <= 1.0):
+            # should never get below 1C (0 is indicator of error)
             log.error("Kiln ERROR: average temp is below zero! "+str(self.kilnTemps[0]))
             log.error("there is error somewhere, so shutdown")
             moHardware.EmergencyOff()
@@ -538,6 +538,9 @@ class Kiln:
     def updateTemperatures(self):
         ''' retrieve thermocouple values degC, avg the ones we want '''
         kTemps = moData.getValue(keyForKType())
+        # need to check if KTypes are valid, which should reflect if errors elsewhere in Thermocouple chain
+        #error is all values = 0, chk ktypeStatus?
+
         # print("Kiln ktypes read as: ", kTemps)
         sum = 0.0
         self.kilnTemps[1] = kTemps[kType_lower]
@@ -553,6 +556,7 @@ class Kiln:
         else:
             # use only the lower (first) ktype = bottom
             self.kilnTemps[0] = self.kilnTemps[1]
+
         pass
 
     def updateDistance(self):

--- a/moGui_Kiln.py
+++ b/moGui_Kiln.py
@@ -125,6 +125,17 @@ class ModacAppWindow(object):
     def close(self, *args):
         self.MainWindow.destroy()
     
+    def on_gtk_quit_activate(self, widget, data=None):
+        log.debug("Quit Activated")
+        #modacExit()
+        self.close()
+        pass
+
+    def on_ShutdownServer_activate(self, widget, data=None):
+        log.debug("Shutdown Server Activated")
+        moCommand.cmdShutdown()
+        pass
+
     def on_winMain_destroy(self, widget, data=None):
         log.debug("on_winMain_destory")
         #self.shutdown()

--- a/moGui_all.py
+++ b/moGui_all.py
@@ -120,7 +120,10 @@ class ModacAppWindow(object):
         
         self.ad16Panel = ad16Panel.ad16Panel()
         self.notebook.append_page(self.ad16Panel.box, self.ad16Panel.label)
-        
+
+        self.enviroPanel = enviroPanel.enviroPanel()
+        self.notebook.append_page(self.enviroPanel.box, self.enviroPanel.label)
+
 
         #  add here and then in updatePanels
         
@@ -132,7 +135,18 @@ class ModacAppWindow(object):
             
     def close(self, *args):
         self.MainWindow.destroy()
-    
+
+    def on_gtk_quit_activate(self, widget, data=None):
+        log.debug("Quit Activated")
+        self.close()
+        pass
+
+
+    def on_ShutdownServer_activate(self, widget, data=None):
+        log.debug("Shutdown Server Activated")
+        moCommand.cmdShutdown()
+        pass
+
     def on_winMain_destroy(self, widget, data=None):
         log.debug("on_winMain_destory")
         #self.shutdown()

--- a/modac/leicaDistoAsync.py
+++ b/modac/leicaDistoAsync.py
@@ -66,7 +66,7 @@ LeicaDisto Module holds singleton State and methods to talk with BLE Device
 # moHardware usual init() and update() are here usage questionable
 # 
 useLeica = True # flag to say we are using or not using Leica distance sensor
-#useLeica = False # flag to say we are using or not using Leica distance sensor
+useLeica = False # flag to say we are using or not using Leica distance sensor
 
 import sys
 this = sys.modules[__name__]

--- a/modac/moCommand.py
+++ b/modac/moCommand.py
@@ -39,6 +39,12 @@ def cmdRunKilnScript(param={}):
 def cmdHello():
     moClient.sendCommand(keyForHello(),())
 
+def cmdGoodbye():
+    moClient.sendCommand(keyForGoodbye(), ())
+
+def cmdShutdown():
+    moClient.sendCommand(keyForShutdown(), ())
+
 def cmdStopKilnScript():
     moClient.sendCommand(keyForStopKilnScript(),())
 

--- a/modac/moKeys.py
+++ b/modac/moKeys.py
@@ -57,6 +57,7 @@ def keyForKTypeStatus() : return keyForKType()+ "_" + keyForStatus()
 #keys for commands from clients
 def keyForHello() : return "Hello"
 def keyForGoodbye() : return "Goodbye"
+def keyForShutdown(): return "Shutdown"
 
 def keyForModacCmd(): return "modac"
 def keyForBinaryCmd(): return "binaryCmd"

--- a/modac/moKeys.py
+++ b/modac/moKeys.py
@@ -19,7 +19,7 @@ def keyForShutdown():   return "shutdown"
 # generic keys used by various components
 # timestamp key used for all data, enviro and leicaDisto
 def keyForTimeStamp(): return "timestamp"
-# Generic key for State used by any state machine in its own context
+# Generic keywords for State, etc used by any state machine in its own context
 def keyForState(): return 'State'
 def keyForStatus(): return "Status"
 def keyForScript(): return "Script"
@@ -49,6 +49,10 @@ def keyForKType(): return "kType"
 # Leica Disto D1 distance sensor
 def keyForLeicaDisto(): return "leicaD1"
 def keyForDistance(): return "distance"
+
+# some combined keys
+def keyForAD16Status() : return keyForAD16()+ "_" + keyForStatus()
+def keyForKTypeStatus() : return keyForKType()+ "_" + keyForStatus()
 
 #keys for commands from clients
 def keyForHello() : return "Hello"

--- a/modac/moNetwork.py
+++ b/modac/moNetwork.py
@@ -57,7 +57,7 @@ def cmdAddress():
     return this.__cmdAddress
 
 # ms timeout for cmd recieve. CmdListener loop delays any checks this long
-def rcvTimeout(): return 2*1000
+def rcvTimeout(): return 500 # was 2*1000
 def sendTimeout(): return 10
 
 #################################

--- a/modac/moStatus.py
+++ b/modac/moStatus.py
@@ -1,0 +1,12 @@
+# generic common Status enum
+
+from enum import Enum
+
+class moStatus(Enum):
+    Error = -100
+    Default = 0
+    Initialized = 1
+    OK = 2
+    Simulated = 3
+
+

--- a/modacGUI/enviroPanel.py
+++ b/modacGUI/enviroPanel.py
@@ -95,7 +95,7 @@ class enviroPanel():
         # ToDo: check timestamp ? if it is same as last, then nothing changed (so what was received?)
         self.timestamp = moData.getValue(keyForTimeStamp())
         enviro = moData.getValue(keyForEnviro())
-        log.debug("enviro Update = "+str( enviro))
+        #log.debug("enviro Update = "+str( enviro))
         temperature = enviro[keyForTemperature()]
         humidity = enviro[keyForHumidity()]
         pressure = enviro[keyForPressure()]

--- a/modacGUI/modac2.glade
+++ b/modacGUI/modac2.glade
@@ -108,12 +108,27 @@ Joe Ritter - MorphOptic</property>
                       </object>
                     </child>
                     <child>
+                      <object class="GtkSeparatorMenuItem">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                      </object>
+                    </child>
+                    <child>
                       <object class="GtkImageMenuItem" id="gtk_quit">
                         <property name="label">gtk-quit</property>
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
                         <property name="use_underline">True</property>
                         <property name="use_stock">True</property>
+                        <signal name="activate" handler="on_gtk_quit_activate" swapped="no"/>
+                      </object>
+                    </child>
+                    <child>
+                      <object class="GtkMenuItem" id="ShutdownServer">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="label">Shutdown Server</property>
+                        <signal name="activate" handler="on_ShutdownServer_activate" swapped="no"/>
                       </object>
                     </child>
                   </object>


### PR DESCRIPTION
AD16 failure is now recognized and KType thermocouples will give [0,0,0,0] values, which Kiln recognizes as bad and thus cancel (without notification) any running Script.
Notification of dead script is something the Clients need to recognize, but that is beyond this fix.  See the TK Gui branch for developments there.
Also slid in a command to SHUTDOWN the server from client.  This is a security issue as there is no encryption etc on simply commands.  The whole Comm system should be examined for better ways to deal with commands from clients.
