### PR TITLE
Test ad16 - more fixes 

### DIFF
--- a/kilnControl/kiln.py
+++ b/kilnControl/kiln.py
@@ -380,10 +380,17 @@ class Kiln:
                 self.lastCheckHeatingTemp = self.kilnTemps[0]
             else :
                 if (currentTime - self.lastCheckHeatingTime).total_seconds() > self.overHeatTime:
-                    log.error("emergency!!! temperature too high, shutting down")
-                    self.terminateScript()
-                    moHardware.EmergencyOff()
-                    return
+                    # its been a while since we checked; has temp changed?
+                    if self.lastCheckHeatingTemp < self.kilnTemps[0]:
+                        # its heating, so we good
+                        self.lastCheckHeatingTime = currentTime
+                        self.lastCheckHeatingTemp = self.kilnTemps[0]
+                    else:
+                        # no change in temp? something wrong
+                        log.error("Temperatures didnt change but supposed to be Heating - ERROR!!!")
+                        self.terminateScript()
+                        moHardware.EmergencyOff()
+                        return
 
         # if we are WAY TOO HOT, shut down kil run and turn on exhaust
         if enableEStop:

--- a/modac/kType.py
+++ b/modac/kType.py
@@ -133,7 +133,7 @@ def asArray():
     # these are in 0-5v, need in mV range for use with conversion library
     # it is not clear if we should be using the roomTemp as zero point
     # that might need to be a constant from testing with ice water
-    roomTemp = enviro.degC()
+    #roomTemp = enviro.degC()
     # only look at the ad24 that are identified by the kTypeIdx array
     for adIdx in kTypeIdx:
         try:

--- a/modac/kType.py
+++ b/modac/kType.py
@@ -103,7 +103,7 @@ def update():
     #assert not moData.getValue(keyForAD24()) == None
     #assert not moData.getValue(keyForEnviro()) == None
     if not this.simulation:
-        # not a simulation=  watch for sensor errors
+        # not a simulation=  watch for sensor errors (done in asArray)
         moData.update(keyForKType(), asArray())
     else:
         assert not this.simulator == None

--- a/modac/moData.py
+++ b/modac/moData.py
@@ -49,6 +49,7 @@ import datetime, json
 
 from enum import Enum
 class moDataStatus(Enum):
+    Error = -2
     Shutdown = -1
     Startup = 0
     Initialized = 0
@@ -107,8 +108,16 @@ def init(client=False):
 def setStatusInitialized():
     update(keyForStatus(),moDataStatus.Initialized.name)
 
+def setStatusError():
+    update(keyForStatus(),moDataStatus.Error.name)
+
 def setStatusRunning():
     update(keyForStatus(),moDataStatus.Running.name)
+
+def getStatus():
+    statusName = getValue(keyForStatus())
+    status = moDataStatus[statusName]
+    return status
 
 def updateTimestamp():
     update(keyForTimeStamp(), datetime.datetime.now())


### PR DESCRIPTION
disconnected sensors were causing exceptions in moHardware.update() that were not caught
now they are.  moData will set its status to Error too
The kiln and primary trio threads notice this and cause modac_server to suicide
This should keep kiln from burning down the building.